### PR TITLE
disable debug prints unless DEBUG is defined

### DIFF
--- a/src/curve_server.cpp
+++ b/src/curve_server.cpp
@@ -38,6 +38,10 @@
 #include "curve_server.hpp"
 #include "wire.hpp"
 
+#ifndef DEBUG
+#define puts(m) do {} while(0)
+#endif
+
 zmq::curve_server_t::curve_server_t (session_base_t *session_,
                                      const std::string &peer_address_,
                                      const options_t &options_) :


### PR DESCRIPTION
By default ZMQ prints debug messages to standard output that look like this

```
CURVE I: cannot open client HELLO -- wrong server key?
CURVE I: cannot open client HELLO -- wrong server key?
CURVE I: cannot open client HELLO -- wrong server key?
CURVE I: cannot open client HELLO -- wrong server key?
CURVE I: cannot open client HELLO -- wrong server key?
CURVE I: cannot open client HELLO -- wrong server key?
CURVE I: cannot open client HELLO -- wrong server key?
```

This gets really annoying really fast, and there are other mechanisms to help diagnose connection problems.  Disable these messages unless DEBUG is defined

cc @thlorenz @brycebaril 