### PR TITLE
build: gyp modifications for v4.2.5

### DIFF
--- a/zmq.gyp
+++ b/zmq.gyp
@@ -70,7 +70,7 @@
   'targets': [
     {
       'target_name': 'libzmq',
-      'type': '<(library)',
+      'type': 'static_library',
       'includes': [ 'zmq.gypi' ],
       'sources': [ '<@(zmqsources)' ],
       'copies': [{

--- a/zmq.gypi
+++ b/zmq.gypi
@@ -20,6 +20,8 @@
       'src/ctx.hpp',
       'src/curve_client.cpp',
       'src/curve_client.hpp',
+      'src/curve_mechanism_base.cpp',
+      'src/curve_mechanism_base.hpp',
       'src/curve_server.cpp',
       'src/curve_server.hpp',
       'src/dbuffer.hpp',
@@ -80,6 +82,8 @@
       'src/mailbox_safe.hpp',
       'src/mechanism.cpp',
       'src/mechanism.hpp ',
+      'src/mechanism_base.cpp',
+      'src/mechanism_base.hpp ',
       'src/metadata.cpp',
       'src/metadata.hpp',
       'src/msg.cpp',
@@ -218,6 +222,8 @@
       'src/ypipe_base.hpp',
       'src/ypipe_conflate.hpp',
       'src/yqueue.hpp',
+      'src/zap_client.cpp',
+      'src/zap_client.hpp',
       'src/zmq.cpp',
       'src/zmq_utils.cpp'
     ]


### PR DESCRIPTION
Add new source files and force the library to be built as static.
The `<library)` was working previously because the library was only
build from `nsolid-node` only and it inherited the `static_library` from
node itself. As now it's used from the bindings for the
`scarab-zmq-agent` addon, and nodejs addons are built as shared
libraries, it needs to be forced.
